### PR TITLE
Check for error before checking for data end

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,11 +72,11 @@ function SIOSource (sio, id, opt) {
     log('reading')
     if (end) return cb(end)
     q.get((err, data) => {
+      if (err) return cb(err)
       if (data.end) {
         q.error(data.end)
         return cb(data.end)
       }
-      if (err) return cb(err)
       return cb(null, data.data)
     })
   }


### PR DESCRIPTION
I was getting an error in the lines of: "cannot read `end` of undefined" which meant `data` was undefined. Maybe this was happening because an error was being sent but the check for it happened after trying to access `data.end`

I changed this locally and the error stopped.